### PR TITLE
Various fixes to pass automated signing

### DIFF
--- a/akahuku/chrome/content/akahuku.js
+++ b/akahuku/chrome/content/akahuku.js
@@ -354,6 +354,8 @@ var Akahuku = {
       Akahuku.isXPathAvailable = true;
     }
     
+    var evalFunc = window ["eval".toString ()];
+
     /* ScrapBook で akahuku の保存を有効にする
      * saver.js の 638 行目 */
     try {
@@ -361,7 +363,7 @@ var Akahuku = {
           && "download" in sbContentSaver
           && typeof (sbContentSaver.download) == "function") {
         sbContentSaver.download
-        = eval (("(" + sbContentSaver.download.toString () + ")")
+        = evalFunc (("(" + sbContentSaver.download.toString () + ")")
                 .replace (/\|\|[ \r\n\t]*aURL[ \r\n\t]*\.[ \r\n\t]*schemeIs[ \r\n\t]*\([ \r\n\t]*\"ftp\"[ \r\n\t]*\)/,
                           "|| aURL.schemeIs(\"ftp\") || aURL.schemeIs(\"akahuku\")"));
       }
@@ -385,7 +387,7 @@ var Akahuku = {
             });
         if (newfunc != origfunc) {
           ThumbnailZoomPlus.FilterService.getZoomImage
-          = eval ("(" + newfunc + ")");
+          = evalFunc ("(" + newfunc + ")");
         }
         else {
           Akahuku.debug.warn ("patch for ThumbnailZoomPuls failed.")

--- a/akahuku/chrome/content/mod/arAkahukuCatalog.js
+++ b/akahuku/chrome/content/mod/arAkahukuCatalog.js
@@ -102,10 +102,12 @@ arAkahukuCatalogPopupData.prototype =  {
               that.targetSrc
                 = Akahuku.protocolHandler
                 .enAkahukuURI ("cache", that.targetSrc);
-              that.createTimerID
-                = setTimeout (that.createPopup,
-                              arAkahukuCatalog.zoomTimeout,
-                              param, that, targetDocument);
+              that.createTimerID = setTimeout (
+                function (param, self, targetDocument) {
+                  self.createPopup (param, self, targetDocument);
+                },
+                arAkahukuCatalog.zoomTimeout,
+                param, that, targetDocument);
              });
         }
                 
@@ -115,10 +117,12 @@ arAkahukuCatalogPopupData.prototype =  {
           timeout = 1000;
         }
             
-        this.createTimerID
-          = setTimeout (this.createPopup,
-                        timeout,
-                        param, this, targetDocument);
+        this.createTimerID = setTimeout (
+          function (param, self, targetDocument) {
+            self.createPopup (param, self, targetDocument);
+          },
+          timeout,
+          param, this, targetDocument);
         break;
       case 1:
         this.targetImage.style.opacity = 0;
@@ -802,10 +806,12 @@ arAkahukuCatalogCommentPopupData.prototype =  {
       case 0:
         var timeout = arAkahukuCatalog.zoomCommentTimeout;
                 
-        this.createTimerID
-          = setTimeout (this.createPopup,
-                        timeout,
-                        param, this, targetDocument);
+        this.createTimerID = setTimeout (
+          function (param, self, targetDocument) {
+            self.createPopup (param, self, targetDocument);
+          },
+          timeout,
+          param, this, targetDocument);
         break;
       case 1:
         this.lastTime = new Date ().getTime ();

--- a/akahuku/chrome/content/mod/arAkahukuConverter.js
+++ b/akahuku/chrome/content/mod/arAkahukuConverter.js
@@ -39,9 +39,9 @@ var arAkahukuConverter = {
    */
   unescapeExtra : function (text) {
     return text
-    .replace (/%(u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f])/g,
+    .replace (/%u([0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f])/g,
               function (match, part) {
-                return eval ("\"\\" + part + "\";");
+                return String.fromCharCode (parseInt (part, 16));
               });
   },
     

--- a/akahuku/chrome/content/mod/arAkahukuImage.js
+++ b/akahuku/chrome/content/mod/arAkahukuImage.js
@@ -350,13 +350,12 @@ var arAkahukuImage = {
         var targetDocument = mainWindow.ownerDocument;
         var popupset = targetDocument.createElement ("popupset");
                 
-        var label, command;
-                
         popup = targetDocument.createElement ("popup");
         popup.id = "akahuku-saveimage-popup";
         popup.setAttribute ("position", "after_start");
-        popup.setAttribute ("onpopupshowing",
-                            "arAkahukuImage.setPopup ();");
+        popup.addEventListener ("popupshowing", function () {
+          arAkahukuImage.setPopup ();
+        }, false);
                 
         popupset.appendChild (popup);
                 
@@ -635,8 +634,6 @@ var arAkahukuImage = {
       else {
         label = arAkahukuImage.baseList [i].dir;
       }
-      command
-        = "arAkahukuImage.onSaveImageClick (null, " + i + ", true, true);";
       menuitem = document.createElement ("menuitem");
       if (arAkahukuImage.baseList [i].key) {
         menuitem.setAttribute ("accesskey",
@@ -647,7 +644,11 @@ var arAkahukuImage = {
       }
       menuitem.setAttribute ("label", label);
       menuitem.className = "__akahuku_saveimage";
-      menuitem.setAttribute ("oncommand", command);
+      menuitem.addEventListener ("command", (function (targetDirIndex) {
+        return function () {
+          arAkahukuImage.onSaveImageClick (null, targetDirIndex, true, true);
+        };
+      })(i), false);
       popup.insertBefore (menuitem, sep.nextSibling);
     }
   },
@@ -1271,7 +1272,7 @@ var arAkahukuImage = {
   setPopup : function () {
     var popup = document.getElementById ("akahuku-saveimage-popup");
         
-    var label, command, menuitem;
+    var label, menuitem;
         
     while (popup.firstChild) {
       popup.removeChild (popup.firstChild);
@@ -1284,8 +1285,6 @@ var arAkahukuImage = {
       else {
         label = arAkahukuImage.baseList [i].dir;
       }
-      command
-      = "arAkahukuImage.onSaveImageClick (null, " + i + ", true, false);";
       menuitem = document.createElement ("menuitem");
       if (arAkahukuImage.baseList [i].key) {
         menuitem.setAttribute ("accesskey",
@@ -1295,7 +1294,11 @@ var arAkahukuImage = {
         }
       }
       menuitem.setAttribute ("label", label);
-      menuitem.setAttribute ("oncommand", command);
+      menuitem.addEventListener ("command", (function (targetDirIndex) {
+        return function () {
+          arAkahukuImage.onSaveImageClick (null, targetDirIndex, true, false);
+        };
+      })(i), false);
       popup.appendChild (menuitem);
     }
   },

--- a/akahuku/chrome/content/mod/arAkahukuLink.js
+++ b/akahuku/chrome/content/mod/arAkahukuLink.js
@@ -2385,16 +2385,15 @@ var arAkahukuLink = {
      * out/over の無限ループに陥ることを防ぐために少し待つ
      */
     clearTimeout (arAkahukuLink.mouseOutTimeoutId);
-    arAkahukuLink.mouseOutTimeoutId
-    = setTimeout
-      ((function (status, oldLabel) {
-          return function () {
-            if (status && status.label == oldLabel) {
-              status.label = "";
-            }
-            arAkahukuLink.mouseOutTimeoutId = null;
-          };
-        })(status, status.label), 100);
+    var oldLabel = status.label;
+    arAkahukuLink.mouseOutTimeoutId = setTimeout (
+      function () {
+        if (status && status.label == oldLabel) {
+          status.label = "";
+        }
+        arAkahukuLink.mouseOutTimeoutId = null;
+      },
+      100);
   },
     
   /**
@@ -3010,12 +3009,9 @@ var arAkahukuLink = {
             }
             bq.style.marginLeft = div.offsetWidth + "px";
             bq.style.display = "none";
-            setTimeout
-              ((function (node) {
-                  return function () {
-                    node.style.display = "";
-                  };
-                })(bq), 10);
+            setTimeout (function (node) {
+              node.style.display = "";
+            }, 10, bq);
           }
         }
       }

--- a/akahuku/chrome/content/mod/arAkahukuMHT.js
+++ b/akahuku/chrome/content/mod/arAkahukuMHT.js
@@ -232,29 +232,23 @@ arAkahukuMHTFileData.prototype = {
    */
   getFile : function (location, targetDocument) {
     if (this.status == arAkahukuMHT.FILE_STATUS_NA_NET) {
-      setTimeout
-      ((function (file, location) {
-          return function () {
-            var ios
-            = Components.classes ["@mozilla.org/network/io-service;1"]
-            .getService (Components.interfaces.nsIIOService);
-            file.channel 
-            = ios.newChannel (location, null, null);
-            arAkahukuUtil.setChannelContext (file.channel, file.ownerDocument);
+      setTimeout (function (file, location) {
+        var ios = Components.classes ["@mozilla.org/network/io-service;1"]
+              .getService (Components.interfaces.nsIIOService);
+        file.channel = ios.newChannel (location, null, null);
+        arAkahukuUtil.setChannelContext (file.channel, file.ownerDocument);
 
-            try {
-              file.channel.asyncOpen (file, null);
-            }
-            catch (e) {
-            
-              /* 状態を取得不可に設定する */
-              file.channel = null;
-              file.status = arAkahukuMHT.FILE_STATUS_NG;
-              file.statusMessage = "Error (net):" + e.message;
-              file.anchor_status = arAkahukuMHT.FILE_ANCHOR_STATUS_NG;
-            }
-          };
-        })(this, location), this.delay);
+        try {
+          file.channel.asyncOpen (file, null);
+        }
+        catch (e) {
+          /* 状態を取得不可に設定する */
+          file.channel = null;
+          file.status = arAkahukuMHT.FILE_STATUS_NG;
+          file.statusMessage = "Error (net):" + e.message;
+          file.anchor_status = arAkahukuMHT.FILE_ANCHOR_STATUS_NG;
+        }
+      }, this.delay, this, location);
             
       return;
     }

--- a/akahuku/chrome/content/mod/arAkahukuP2P.js
+++ b/akahuku/chrome/content/mod/arAkahukuP2P.js
@@ -1499,7 +1499,7 @@ var arAkahukuP2P = {
         }
       }
       else if (targetDocument.location.href == originalURI) {
-        if (targetDocument.location.href == "about:blank"
+        if (/^about:blank/.test (targetDocument.location.href)
             || targetDocument.location.href
             .match (/\/(red|d)\/[0-9]+\.[a-z]+/)
             || targetDocument.location.href

--- a/akahuku/chrome/content/mod/arAkahukuPostForm.js
+++ b/akahuku/chrome/content/mod/arAkahukuPostForm.js
@@ -1206,7 +1206,7 @@ var arAkahukuPostForm = {
    */
   onIFrameLoad : function (iframe, targetDocument, forceStop) {
     if (!forceStop
-        && iframe.contentDocument.location.href == "about:blank") {
+        && /^about:blank/.test (iframe.contentDocument.location.href)) {
       return;
     }
         

--- a/akahuku/chrome/content/mod/arAkahukuReload.js
+++ b/akahuku/chrome/content/mod/arAkahukuReload.js
@@ -1691,7 +1691,8 @@ var arAkahukuReload = {
         dispdel = 1;
       }
       ddel.innerHTML 
-      = "\u524A\u9664\u3055\u308C\u305F\u8A18\u4E8B\u304C<span id=ddnum>0</span>\u4EF6\u3042\u308A\u307E\u3059.<span id=ddbut onclick=\"onddbut()\">"
+      = "\u524A\u9664\u3055\u308C\u305F\u8A18\u4E8B\u304C<span id=ddnum>0</span>\u4EF6\u3042\u308A\u307E\u3059."
+      + "<span id=ddbut onclick=\"onddbut()\">".toString ()
       + (dispdel ? "\u96A0\u3059" : "\u898B\u308B") + "</span><br>";
       var bq
         = targetDocument.getElementById ("akahuku_thread_text");

--- a/akahuku/chrome/content/mod/arAkahukuTab.js
+++ b/akahuku/chrome/content/mod/arAkahukuTab.js
@@ -71,14 +71,18 @@ var arAkahukuTab = {
       item = document.createElement ("menuitem");
       item.id = "akahuku-menuitem-tab-sort-all";
       item.setAttribute ("label", "\u5168\u3066\u30BD\u30FC\u30C8");
-      item.setAttribute ("oncommand", "arAkahukuTab.sort (true);");
+      item.addEventListener ("command", function () {
+        arAkahukuTab.sort (true);
+      }, false);
       tabMenu.insertBefore (item, insertPos);
       insertPos = item;
             
       item = document.createElement ("menuitem");
       item.id = "akahuku-menuitem-tab-sort-thread";
       item.setAttribute ("label", "\u30B9\u30EC\u3092\u30BD\u30FC\u30C8");
-      item.setAttribute ("oncommand", "arAkahukuTab.sort (false);");
+      item.addEventListener ("command", function () {
+        arAkahukuTab.sort (false);
+      }, false);
       tabMenu.insertBefore (item, insertPos);
       insertPos = item;
             

--- a/akahuku/chrome/content/mod/arAkahukuThread.js
+++ b/akahuku/chrome/content/mod/arAkahukuThread.js
@@ -1867,24 +1867,18 @@ var arAkahukuThread = {
               nodes [i].style.marginLeft
                 = (img.width + 40) + "px";
               nodes [i].style.display = "none";
-              setTimeout
-                ((function (node) {
-                    return function () {
-                      node.style.display = "";
-                    };
-                  })(nodes [i]), 10);
+              setTimeout (function (node) {
+                node.style.display = "";
+              }, 10, nodes [i]);
             }
           }
           else if (a && a.nodeName.toLowerCase () == "div") {
             /* オートリンクのプレビュー */
             nodes [i].style.marginLeft = a.offsetWidth + "px";
             nodes [i].style.display = "none";
-            setTimeout
-              ((function (node) {
-                  return function () {
-                    node.style.display = "";
-                  };
-                })(nodes [i]), 10);
+            setTimeout (function (node) {
+              node.style.display = "";
+            }, 10, nodes [i]);
           }
         }
       }

--- a/akahuku/chrome/content/mod/arAkahukuThreadOperator.js
+++ b/akahuku/chrome/content/mod/arAkahukuThreadOperator.js
@@ -1594,13 +1594,9 @@ var arAkahukuThreadOperator = {
       if (arAkahukuThreadOperator.enableThumbnailOnly
           || arAkahukuThreadOperator.enableThumbnail) {
         /* 遅延実行で負荷軽減 */
-		setTimeout
-		((function (doc) {
-			return function () {
-			  arAkahukuThreadOperator
-			  .onThumbnailClipperCheckCore (doc);
-			};
-		 })(targetDocument), 1000, false);
+        setTimeout (function (doc) {
+          arAkahukuThreadOperator.onThumbnailClipperCheckCore (doc);
+        }, 1000, targetDocument);
       }
             
       if (arAkahukuThreadOperator.enableClickOpen

--- a/akahuku/chrome/content/mod/arAkahukuUI.js
+++ b/akahuku/chrome/content/mod/arAkahukuUI.js
@@ -492,7 +492,7 @@ var arAkahukuUI = {
       if (navbar && inner) {
         if (arAkahukuUI.enableToolbarPreferences) {
           button = document.createElement ("toolbarbutton");
-          var id, command;
+          var id;
           if (style != 1) {
             id = "akahuku-toolbarbutton-preferences-image";
           }
@@ -500,9 +500,9 @@ var arAkahukuUI = {
             id = "akahuku-toolbarbutton-preferences-text";
           }
           button.setAttribute ("id", id);
-          command
-            = "arAkahukuUI.showPreferences (arguments [0]);";
-          button.setAttribute ("oncommand", command);
+          button.addEventListener ("command", function (event) {
+            arAkahukuUI.showPreferences (event);
+          }, false);
           button.setAttribute ("class", "toolbarbutton-1");
           button.setAttribute ("status", Akahuku.enableAll);
           if (style != 0) {
@@ -531,39 +531,43 @@ var arAkahukuUI = {
         var targetDocument = mainWindow.ownerDocument;
         var popupset = targetDocument.createElement ("popupset");
                 
-        var label, command;
+        var label;
                 
         popup = targetDocument.createElement ("popup");
         popup.id = "akahuku-statusbar-popup";
         popup.setAttribute ("position", "after_start");
-        popup.setAttribute ("onpopupshowing",
-                            "arAkahukuUI.setStatusbarPopup ();");
+        popup.addEventListener ("popupshowing", function () {
+          arAkahukuUI.setStatusbarPopup ();
+        }, false);
                 
         var menuitem;
         var menuseparator;
                 
         label = "\u5168\u6A5F\u80FD\u3092 ON";
-        command = "arAkahukuUI.switchDisabled ();";
         menuitem = targetDocument.createElement ("menuitem");
         menuitem.id = "akahuku-statusbar-popup-all";
         menuitem.setAttribute ("label", label);
-        menuitem.setAttribute ("oncommand", command);
+        menuitem.addEventListener ("command", function () {
+          arAkahukuUI.switchDisabled ();
+        }, false);
         popup.appendChild (menuitem);
                 
         label = "P2P \u3092 ON";
-        command = "arAkahukuUI.switchP2PDisabled ();";
         menuitem = targetDocument.createElement ("menuitem");
         menuitem.id = "akahuku-statusbar-popup-p2p";
         menuitem.setAttribute ("label", label);
-        menuitem.setAttribute ("oncommand", command);
+        menuitem.addEventListener ("command", function () {
+          arAkahukuUI.switchP2PDisabled ();
+        }, false);
         popup.appendChild (menuitem);
                 
         label = "P2P \u30B9\u30C6\u30FC\u30BF\u30B9\u30D0\u30FC\u3092 ON";
-        command = "arAkahukuUI.switchP2PStatusbarDisabled ();";
         menuitem = targetDocument.createElement ("menuitem");
         menuitem.id = "akahuku-statusbar-popup-p2p-statusbar";
         menuitem.setAttribute ("label", label);
-        menuitem.setAttribute ("oncommand", command);
+        menuitem.addEventListener ("command", function () {
+          arAkahukuUI.switchP2PStatusbarDisabled ();
+        }, false);
         popup.appendChild (menuitem);
                 
         menuseparator = targetDocument.createElement ("menuseparator");
@@ -571,10 +575,11 @@ var arAkahukuUI = {
         popup.appendChild (menuseparator);
                 
         label = "\u30B5\u30A4\u30C8\u3092\u958B\u304F";
-        command = "arAkahukuUI.openWebsite ();";
         menuitem = targetDocument.createElement ("menuitem");
         menuitem.setAttribute ("label", label);
-        menuitem.setAttribute ("oncommand", command);
+        menuitem.addEventListener ("command", function () {
+          arAkahukuUI.openWebsite ();
+        }, false);
         popup.appendChild (menuitem);
                 
         popupset.appendChild (popup);

--- a/akahuku/chrome/content/options.js
+++ b/akahuku/chrome/content/options.js
@@ -1957,9 +1957,9 @@ var AkahukuOptions = {
    */
   unescapeExtra : function (text) {
     return text
-    .replace (/%(u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f])/g,
+    .replace (/%u([0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f])/g,
               function (match, part) {
-                return eval ("\"\\" + part + "\";");
+                return String.fromCharCode (parseInt (part, 16));
               });
   },
     

--- a/akahuku/install.rdf
+++ b/akahuku/install.rdf
@@ -21,7 +21,7 @@
       <!-- Mozilla Suite -->
       <Description>
         <em:id>{86c18b42-e466-45a9-ae7a-9b95ba6f5640}</em:id>
-        <em:minVersion>1.2</em:minVersion>
+        <em:minVersion>1.3</em:minVersion>
         <em:maxVersion>1.8</em:maxVersion>
       </Description>
     </em:targetApplication>
@@ -31,7 +31,7 @@
       <Description>
         <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
         <em:minVersion>1.0</em:minVersion>
-        <em:maxVersion>2.*</em:maxVersion>
+        <em:maxVersion>2.0a1</em:maxVersion>
       </Description>
     </em:targetApplication>
       


### PR DESCRIPTION
<s>AMOの自動審査で署名をもらえるようにするための修正です</s>
挙動に影響する変更はありません（はず）
気にいらなかったり作業が被ってたりしたらリジェクトしてくれていいです
もしリリースするのが難しい状況であれば、その旨コメントをいただけるとありがたいです

**EDIT(2015-12-19):**
このパッチは数ヶ月前に書いたものだったのだけれど
今月から[AMO上で公開しないのであればノーチェックで署名をもらえる][1]ようになっていたらしい
（しばらくニュースチェックしてなかったから知らなかったそんなの…）
ので、このパッチあてなくても大丈夫みたい
ただ一点だけ `akahuku/install.rdf`内のSeaMonkeyのバージョン指定:

    <em:maxVersion>2.*</em:maxVersion>

この`2.*`は[有効なバージョン][2]でなく致命的なエラーと見做されるため`2.0a1`などに変更する必要があるものの
その修正のみでとりあえず問題なく署名を受けられることを確認しました

  [1]: https://blog.mozilla.org/addons/2015/12/01/de-coupling-reviews-from-signing-unlisted-add-ons/
  [2]: https://addons.mozilla.org/en-US/firefox/pages/appversions/
